### PR TITLE
Fix variance typing issue with CommandTree.error decorator

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
     from .commands import ContextMenuCallback, CommandCallback, P, T
 
     ErrorFunc = Callable[
-        [Interaction, AppCommandError],
+        [Interaction[ClientT], AppCommandError],
         Coroutine[Any, Any, Any],
     ]
 
@@ -833,7 +833,7 @@ class CommandTree(Generic[ClientT]):
         else:
             _log.error('Ignoring exception in command tree', exc_info=error)
 
-    def error(self, coro: ErrorFunc) -> ErrorFunc:
+    def error(self, coro: ErrorFunc[ClientT]) -> ErrorFunc[ClientT]:
         """A decorator that registers a coroutine as a local error handler.
 
         This must match the signature of the :meth:`on_error` callback.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
