### PR TITLE
Avoid returning in finally

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -588,22 +588,26 @@ class FFmpegOpusAudio(FFmpegAudio):
         loop = asyncio.get_running_loop()
         try:
             codec, bitrate = await loop.run_in_executor(None, lambda: probefunc(source, executable))
-        except Exception:
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException:
             if not fallback:
                 _log.exception("Probe '%s' using '%s' failed", method, executable)
-                return  # type: ignore
+                return None, None
 
             _log.exception("Probe '%s' using '%s' failed, trying fallback", method, executable)
             try:
                 codec, bitrate = await loop.run_in_executor(None, lambda: fallback(source, executable))
-            except Exception:
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except BaseException:
                 _log.exception("Fallback probe using '%s' failed", executable)
             else:
                 _log.debug("Fallback probe found codec=%s, bitrate=%s", codec, bitrate)
         else:
             _log.debug("Probe found codec=%s, bitrate=%s", codec, bitrate)
-        finally:
-            return codec, bitrate
+
+        return codec, bitrate
 
     @staticmethod
     def _probe_codec_native(source, executable: str = 'ffmpeg') -> Tuple[Optional[str], Optional[int]]:


### PR DESCRIPTION
Specifically reraise KeyboardInterrupt, SystemExit Swallow other BaseExceptions due to the way the standard library uses them and the intent of this function

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
